### PR TITLE
Add release workflow for Linux and macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,32 @@ jobs:
       - name: Package
         shell: bash
         run: |
+          rm -rf package dist
           mkdir -p package dist
           cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} package/
           cp README.md package/
           tar -czf dist/${{ matrix.asset_name }} -C package .
 
-      - name: Upload release asset
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: dist/${{ matrix.asset_name }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create or update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/${{ matrix.asset_name }}
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_name: weather-x86_64-unknown-linux-gnu.tar.gz
+            binary_name: weather
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset_name: weather-aarch64-apple-darwin.tar.gz
+            binary_name: weather
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          mkdir -p package dist
+          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} package/
+          cp README.md package/
+          tar -czf dist/${{ matrix.asset_name }} -C package .
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/${{ matrix.asset_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build release binaries on tag push
- publish Linux and macOS tarballs to GitHub Releases
- package the compiled binary together with README

## Related
Closes #5

## Release behavior
When a tag like `v0.3.1` is pushed, GitHub Actions will:
- build `x86_64-unknown-linux-gnu` on Ubuntu
- build `aarch64-apple-darwin` on macOS
- create and upload release assets to the corresponding GitHub Release

## Notes
- this intentionally starts with Linux + Apple Silicon macOS
- Intel macOS and checksums can be added in a follow-up
